### PR TITLE
gen_boot_image: Make generated image deterministic.

### DIFF
--- a/gen_boot_image.sh
+++ b/gen_boot_image.sh
@@ -104,11 +104,15 @@ popd &>/dev/null
 
 #
 # Convert userspace / kernel into an archive which can then be linked
-# against the elfloader binary.
+# against the elfloader binary. Change to the directory of archive.cpio
+# before this operation to avoid polluting the symbol table with references
+# to the temporary directory.
 #
+pushd "${TEMP_DIR}" >/dev/null
 ${TOOLPREFIX}ld -T "${SCRIPT_DIR}/archive.bin.lds" \
-        --oformat ${FORMAT} -r -b binary ${TEMP_DIR}/archive.cpio \
+        --oformat ${FORMAT} -r -b binary archive.cpio \
         -o "${TEMP_DIR}/archive.o" || fail
+popd >/dev/null
 
 #
 # Link everything together to produce the final ELF image.


### PR DESCRIPTION
When linking binary data in this manner, the linker introduces symbols to point
to the start and size, based on the name of the file. The symbol name in this
case was including a prefix of the temporary directory used for staging
archive.cpio. This commit removes this prefix from such symbols, for a more
deterministic final binary.

JIRA: CAMKES-280
